### PR TITLE
fix/customization compulsory

### DIFF
--- a/pitchprint.php
+++ b/pitchprint.php
@@ -393,7 +393,7 @@
 			// var_dump($pp_customization_required);die();
 			$pp_customization_required = 
 				( $pp_customization_required === 'undefined' || 
-				( isset($pp_customization_required) && strlen($pp_customization_required) == 0) ) ? 'undefined' : ( $pp_customization_required ? 1 : 0 );
+				( isset($pp_customization_required) && strlen($pp_customization_required) == 0) ) ? 0 : ( $pp_customization_required ? 1 : 0 );
 			$pp_pdf_download = 
 				( $pp_pdf_download === 'undefined' || 
 				( isset($pp_pdf_download) && strlen($pp_pdf_download) == 0 ) ) ? 'undefined' : ( $pp_pdf_download ? 1: 0 );


### PR DESCRIPTION
Add to cart button is hidden no matter if option "**Check this to make customization compulsory for this product**" is checked.
The reason is that function **add_pp_edit_button()** sets javascript clients '**customizationRequired'** field to '**undefined**'. 
This could be easy fixed by making it true/false or 1/0, but it looks like 'undefined' is set deliberately.